### PR TITLE
fix: CharSelected packet does not set the User property

### DIFF
--- a/src/network/incoming/game/CharSelected.ts
+++ b/src/network/incoming/game/CharSelected.ts
@@ -26,6 +26,8 @@ export default class CharSelected extends GameClientPacket {
     user.Hp = this.readD();
     user.Mp = this.readD();
 
+    this.User = user;
+
     return true;
   }
 }


### PR DESCRIPTION
Encountered this when testing the move example.

```
    const x = 50 + Math.floor(Math.random() * 50) + login_1.default.Me.X;
                                                                       ^

TypeError: Cannot read properties of undefined (reading 'X')
    at F:\workspace\l2js-client\examples\dist\move.js:31:72
    at GameClient.fire (F:\workspace\l2js-client\dist\mmocore\EventEmitter.js:61:13)
    at F:\workspace\l2js-client\dist\commands\CommandEnter.js:76:41
    at GameClient.fire (F:\workspace\l2js-client\dist\mmocore\EventEmitter.js:61:13)
    at Timeout._onTimeout (F:\workspace\l2js-client\dist\mmocore\MMOClient.js:89:34)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```