### PR TITLE
fix: ECreatureSay type annotation

### DIFF
--- a/src/events/EventTypes.ts
+++ b/src/events/EventTypes.ts
@@ -119,7 +119,7 @@ export declare type ECreatureSay = {
     type: number;
     charName: string;
     npcStringId: number;
-    messages: [];
+    messages: string[];
   };
   once: boolean;
 };


### PR DESCRIPTION
missing type for messages array