### PR TITLE
feat: calculate heading on move

### DIFF
--- a/src/entities/L2Creature.ts
+++ b/src/entities/L2Creature.ts
@@ -430,6 +430,11 @@ export default abstract class L2Creature extends L2Object {
     this.Y = y;
     this.Z = z;
 
+    let angleTarget = Math.atan2(dy - y, dx - x) * (180 / Math.PI);
+    if (angleTarget < 0)
+      angleTarget = 360 + angleTarget;
+    this.Heading = Math.floor(angleTarget * 182.044444444);
+
     const movingVector: Vector = new Vector(dx - this.X, dy - this.Y);
 
     let ticks = Math.ceil(movingVector.length() / (this.CurrentSpeed / 10));


### PR DESCRIPTION
used formula described here: https://maxcheaters.com/topic/116368-help-spawnlist-heading-field/#comment-1633871

Not sure if necessary, but seems to improve characters heading (when clicked in game character usually turned a bit), now it stays static in most cases, but not all?!